### PR TITLE
Replace isGL3core() with isGL3()

### DIFF
--- a/src/demos/es2/RawGL2ES2demo.java
+++ b/src/demos/es2/RawGL2ES2demo.java
@@ -341,7 +341,7 @@ private String fragmentShaderString =
         // GLSL 1.3 is the minimum version that now has to be explicitly set.
         // This allows the shaders to compile using the latest
         // desktop OpenGL 3 and 4 drivers.
-        if(gl.isGL3core()){
+        if(gl.isGL3()){
             System.out.println("GL3 core detected: explicit add #version 130 to shaders");
             vertexShaderString = "#version 130\n"+vertexShaderString;
             fragmentShaderString = "#version 130\n"+fragmentShaderString;


### PR DESCRIPTION
Latest version of javax.media.opengl contains neither GLBase.isGL3core() nor GL2ES2.isGL3core()
